### PR TITLE
Force field in store's __submit endpoint

### DIFF
--- a/plugin_store/main.py
+++ b/plugin_store/main.py
@@ -89,6 +89,7 @@ class PluginStore:
         
         if data["force"]:
             force = data["force"].strip().title() in ["True", "1"]
+            res = None
 
 
         res = await self.database.get_plugin_by_name(name)

--- a/plugin_store/main.py
+++ b/plugin_store/main.py
@@ -86,6 +86,12 @@ class PluginStore:
         version_name = data["version_name"]
         image_url = data["image"]
         file_bin = data["file"].file.read()
+        
+        if data["force"]:
+            force = bool(eval(data["force"].title()))
+
+        if force:
+            print('force: not implemented yet')
 
         res = await self.database.get_plugin_by_name(name)
         if not res:

--- a/plugin_store/main.py
+++ b/plugin_store/main.py
@@ -90,10 +90,12 @@ class PluginStore:
         if data["force"]:
             force = bool(eval(data["force"].title()))
 
-        if force:
-            self.database.remove_artifact(name)
 
         res = await self.database.get_plugin_by_name(name)
+
+        if res and force:
+            await self.database.delete_plugin(res.id)
+
         if not res:
             res = await self.database.insert_artifact(
                 name=name,

--- a/plugin_store/main.py
+++ b/plugin_store/main.py
@@ -89,13 +89,13 @@ class PluginStore:
         
         if data["force"]:
             force = data["force"].strip().title() in ["True", "1"]
-            res = None
 
 
         res = await self.database.get_plugin_by_name(name)
 
         if res and force:
             await self.database.delete_plugin(res.id)
+            res = None
 
         if not res:
             res = await self.database.insert_artifact(

--- a/plugin_store/main.py
+++ b/plugin_store/main.py
@@ -88,7 +88,7 @@ class PluginStore:
         file_bin = data["file"].file.read()
         
         if data["force"]:
-            force = bool(eval(data["force"].title()))
+            force = data["force"].strip().title() in ["True", "1"]
 
 
         res = await self.database.get_plugin_by_name(name)

--- a/plugin_store/main.py
+++ b/plugin_store/main.py
@@ -91,19 +91,21 @@ class PluginStore:
             force = bool(eval(data["force"].title()))
 
         if force:
-            print('force: not implemented yet')
+            self.database.remove_artifact(name)
 
         res = await self.database.get_plugin_by_name(name)
         if not res:
-            res = await self.database.insert_artifact(name=name,
-            author=author,
-            description=description,
-            tags=tags)
+            res = await self.database.insert_artifact(
+                name=name,
+                author=author,
+                description=description,
+                tags=tags
+            )
         elif version_name in [i.name for i in res.versions]:
             return json_response({"message": "Version already exists"}, status=400)
         ver = await self.database.insert_version(res.id,
-        name=version_name,
-        hash=sha256(file_bin).hexdigest()
+            name=version_name,
+            hash=sha256(file_bin).hexdigest()
         )
         await b2_upload(f"versions/{ver.hash}.zip", file_bin)
         await self.upload_image(res, image_url)


### PR DESCRIPTION
This would allow a plugin upload to overwrite the existing copy on the server even if the versions are the same.