### PR TITLE
Fix image_url path + use it on the frontend

### DIFF
--- a/plugin_store/database/models/Artifact.py
+++ b/plugin_store/database/models/Artifact.py
@@ -37,7 +37,7 @@ class Artifact(Base):
 
     @property
     def image_url(self):
-        return f"{constants.CDN_URL}/{self.image_path}"
+        return f"{constants.CDN_URL}{self.image_path}"
 
     @property
     def image_path(self):

--- a/plugin_store/templates/plugin_browser.html
+++ b/plugin_store/templates/plugin_browser.html
@@ -31,7 +31,7 @@
           <div class="row">
             <div class="col-3">
               <img
-                v-bind:src="'https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/artifact_images/'+plugin.name.replace('/', '_')+'.png'"
+                v-bind:src="plugin.image_url"
                 class="img-fluid rounded-start">
             </div>
             <div class="col">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def mock_constants(session_mocker: "MockFixture"):
     """
     Auto-mocking some constants to make sure they are used instead of hardcoded values.
     """
-    session_mocker.patch("constants.CDN_URL", new="hxxp://fake.domain")
+    session_mocker.patch("constants.CDN_URL", new="hxxp://fake.domain/")
 
 
 @pytest.fixture()


### PR DESCRIPTION
- Fix `image_url` path to not contain double slash
- Start using `image_url` on the store frontend.