### PR TITLE
Use only single DB session for all endpoints

### DIFF
--- a/plugin_store/database/models/Artifact.py
+++ b/plugin_store/database/models/Artifact.py
@@ -30,7 +30,7 @@ class Artifact(Base):
     name = Column(Text)
     author = Column(Text)
     description = Column(Text)
-    tags = relationship("Tag", secondary=PluginTag, cascade="all, delete", lazy="selectin")
+    tags = relationship("Tag", secondary=PluginTag, cascade="all, delete", order_by="Tag.tag", lazy="selectin")
     versions = relationship("Version", cascade="all, delete", lazy="selectin")
 
     UniqueConstraint("name")
@@ -53,6 +53,3 @@ class Artifact(Base):
             "tags": [i.tag for i in self.tags],
             "versions": [i.to_dict() for i in reversed(self.versions)],
         }
-
-
-Artifact._query_options = [selectinload(Artifact.tags), selectinload(Artifact.versions)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,7 @@ async def seed_db(db):
     generator = FakePluginGenerator(db, session)
     await generator.create(name="plugin-1", tags=["tag-1", "tag-2"], versions=["0.1.0", "0.2.0", "1.0.0"])
     await generator.create(name="plugin-2", tags=["tag-1", "tag-3"], versions=["1.1.0", "2.0.0"])
-    await generator.create(name="plugin-3", tags=["tag-2", "tag-3"], versions=["3.0.0", "3.1.0", "3.2.0"])
+    await generator.create(name="third", tags=["tag-2", "tag-3"], versions=["3.0.0", "3.1.0", "3.2.0"])
     await generator.create(name="plugin-4", tags=["tag-1"], versions=["1.0.0", "2.0.0", "3.0.0", "4.0.0"])
     session.commit()
 


### PR DESCRIPTION
- submit endpoint was using multiple DB sessions (separate one for each stage of the logic), which wasn't ideal in case of a rollback.
- make sure tags are not duplicated in DB when updating plugins.