### PR TITLE
Fix default value for visibility column

### DIFF
--- a/plugin_store/database/migrations/versions/abe90daeb874_initial_db_setup.py
+++ b/plugin_store/database/migrations/versions/abe90daeb874_initial_db_setup.py
@@ -16,7 +16,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("artifacts", sa.Column("visible", sa.Boolean(), server_default="True", nullable=True))
+    op.add_column("artifacts", sa.Column("visible", sa.Boolean(), server_default="1", nullable=True))
     with op.batch_alter_table("artifacts") as batch_op:
         batch_op.alter_column("visible", nullable=False)
 


### PR DESCRIPTION
- The value of `True` is not valid for sqlite, but it still saves it in DB... but it doesn't work when querying... Changed to `1` which is the correct default internally.