### PR TITLE
Fix version number in discord announcement

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -19,3 +19,4 @@ services:
     restart: unless-stopped
     ports:
         - "5566:5566"
+    command: uvicorn main:app --reload --host 0.0.0.0 --port 5566

--- a/plugin_store/discord.py
+++ b/plugin_store/discord.py
@@ -1,11 +1,15 @@
 from os import getenv
+from typing import TYPE_CHECKING
 
 from discord_webhook import AsyncDiscordWebhook, DiscordEmbed
 
 import constants
 
+if TYPE_CHECKING:
+    from database.models import Artifact, Version
 
-async def post_announcement(plugin):
+
+async def post_announcement(plugin: "Artifact", version: "Version"):
     webhook = AsyncDiscordWebhook(url=getenv("ANNOUNCEMENT_WEBHOOK"))
     embed = DiscordEmbed(title=plugin.name, description=plugin.description, color=0x213997)
 
@@ -15,7 +19,7 @@ async def post_announcement(plugin):
         url=f"https://github.com/{plugin.author}/{plugin.name}",
     )
     embed.set_thumbnail(url=plugin.image_url)
-    embed.set_footer(text=f"Version {plugin.versions[-1].name}")
+    embed.set_footer(text=f"Version {version.name}")
 
     webhook.add_embed(embed)
     await webhook.execute()


### PR DESCRIPTION
- After fastapi changes, versions for extracting last uploaded version number were reversed twice. Now currently uploaded version will be taken instead of extracting the most recent one (which resulted in the actually uploaded version to be extracted, given current default version ordering, but in future it may not be the case). This method should be resistant to such error.
- Added run command override in docker compose for local development. Now it includes autoreload feature, so code changes done during development are automatically applied.
