### PR TITLE
Fixed GHA not finding linters.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9.14-alpine3.16
 ENV POETRY_INSTALLER_MAX_WORKERS=1
 ENV POETRY_VIRTUALENVS_IN_PROJECT=false
 ENV POETRY_VIRTUALENVS_PATH="/root/.venvs"
-ENV VENV_PATH="${POETRY_VIRTUALENVS_PATH}/decky-plugin-store-9TtSrW0h-py3.11"
+ENV VENV_PATH="${POETRY_VIRTUALENVS_PATH}/decky-plugin-store-9TtSrW0h-py3.9"
 
 RUN apk add build-base
 RUN apk add openssl-dev
@@ -25,7 +25,5 @@ COPY ./plugin_store/ /app/plugin_store
 COPY ./tests/ /app/tests
 WORKDIR /app/plugin_store
 ENV PYTHONUNBUFFERED=0
-
-ENTRYPOINT ["poetry", "run", "--"]
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5566"]


### PR DESCRIPTION
- Fixed wrong PATH (introduced when rolling back python bump) causing GHA to fail.
- Removed entrypoint, so GHA and normal docker have the same exec environment.