### PR TITLE
Added `file_field` in version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,15 @@ lint/mypy:
 
 lint: lint/black lint/isort lint/flake8 lint/mypy
 
+migrations/apply:
+	alembic upgrade head
+
+migrations/autogenerate:
+	alembic revision --autogenerate
+
+migrations/create:
+	alembic revision
+
 dc/build:
 	docker-compose -f docker-compose.local.yml build
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -10,7 +10,7 @@ script_location = /app/plugin_store/database/migrations
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
-prepend_sys_path = .
+prepend_sys_path = plugin_store
 
 # timezone to use when rendering the date within the migration file
 # as well as the filename.

--- a/plugin_store/database/migrations/versions/492a599cd718_version_uniqueness.py
+++ b/plugin_store/database/migrations/versions/492a599cd718_version_uniqueness.py
@@ -1,0 +1,35 @@
+"""empty message
+
+Revision ID: 492a599cd718
+Revises: abe90daeb874
+Create Date: 2023-06-13 22:05:19.849032
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "492a599cd718"
+down_revision = "abe90daeb874"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("artifacts") as batch_op_artifacts:
+        batch_op_artifacts.alter_column(
+            "visible", existing_type=sa.BOOLEAN(), nullable=True, existing_server_default=sa.text("'1'")
+        )
+    with op.batch_alter_table("versions") as batch_op_versions:
+        batch_op_versions.add_column(sa.Column("file", sa.Text(), nullable=True))
+        batch_op_versions.create_unique_constraint("unique_version_artifact_id_name", ["artifact_id", "name"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("versions") as batch_op_versions:
+        batch_op_versions.drop_constraint("unique_version_artifact_id_name", type_="unique")
+        batch_op_versions.drop_column("versions", "file")
+    with op.batch_alter_table("artifacts") as batch_op_artifacts:
+        batch_op_artifacts.alter_column(
+            "artifacts", "visible", existing_type=sa.BOOLEAN(), nullable=False, existing_server_default=sa.text("'1'")
+        )

--- a/plugin_store/database/models/Version.py
+++ b/plugin_store/database/models/Version.py
@@ -1,14 +1,26 @@
-from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy import Column, ForeignKey, Integer, Text, UniqueConstraint
 
+import constants
 from ..utils import TZDateTime
 from .Base import Base
 
 
 class Version(Base):
     __tablename__ = "versions"
+    __table_args__ = (UniqueConstraint("artifact_id", "name", name="unique_version_artifact_id_name"),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     artifact_id = Column(Integer, ForeignKey("artifacts.id"))
     name = Column(Text)
     hash = Column(Text)
+    file_field = Column("file", Text, nullable=True)
+
     created = Column("added_on", TZDateTime)
+
+    @property
+    def file_url(self):
+        return f"{constants.CDN_URL}{self.download_path}"
+
+    @property
+    def file(self):
+        return f"artifact_images/{self.hash}.zip"


### PR DESCRIPTION
- Added `file_field` in version to store the path for the plugin file on the backblaze
- Fixed running migrations inside new docker (adjusted path).
- Added makefile helpers for alembic.