### PR TITLE
Add sorting by name or creation date to the /plugins endpoint

### DIFF
--- a/plugin_store/api/__init__.py
+++ b/plugin_store/api/__init__.py
@@ -2,7 +2,6 @@ from functools import reduce
 from operator import add
 from os import getenv
 from typing import TYPE_CHECKING, Optional
-from enum import Enum
 
 import fastapi
 from fastapi import Depends, FastAPI, HTTPException
@@ -43,6 +42,7 @@ app.add_middleware(
     expose_headers=["*"],
 )
 
+
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: "Request", exc: "HTTPException") -> "Response":
     headers = getattr(exc, "headers", None)
@@ -63,6 +63,7 @@ async def auth_token(authorization: str = Depends(APIKeyHeader(name="Authorizati
 @app.get("/", response_class=HTMLResponse)
 async def index():
     return INDEX_PAGE
+
 
 @app.get("/plugins", response_model=list[api_list.ListPluginResponse])
 async def plugins_list(

--- a/plugin_store/api/__init__.py
+++ b/plugin_store/api/__init__.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from operator import add
 from os import getenv
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from enum import auto
 
 import fastapi
@@ -67,27 +67,25 @@ async def index():
 
 
 # TODO: move these enums somewhere to deduplicate them
-class SortOption(StrEnum):
+class SortDirection(StrEnum):
     desc = auto()
     asc = auto()
-    NONE = auto()
 
 class SortType(StrEnum):
     name = auto()
     date = auto()
-    NONE = auto()
 
 @app.get("/plugins", response_model=list[api_list.ListPluginResponse])
 async def plugins_list(
     query: str = "",
     tags: list[str] = fastapi.Query(default=[]),
     hidden: bool = False,
-    sort_by: SortType = SortType.NONE,
-    order_by: SortOption = SortOption.NONE,
+    sort_by: Optional[SortType] = None,
+    sort_direction: SortDirection = SortDirection.desc,
     db: "Database" = Depends(database),
 ):
     tags = list(filter(None, reduce(add, (el.split(",") for el in tags), [])))
-    plugins = await db.search(db.session, query, tags, hidden, sort_by, order_by)
+    plugins = await db.search(db.session, query, tags, hidden, sort_by, sort_direction)
     return plugins
 
 

--- a/plugin_store/api/__init__.py
+++ b/plugin_store/api/__init__.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from operator import add
 from os import getenv
-from typing import TYPE_CHECKING, Optional
+from typing import Optional, TYPE_CHECKING
 
 import fastapi
 from fastapi import Depends, FastAPI, HTTPException
@@ -11,7 +11,7 @@ from fastapi.security import APIKeyHeader
 from fastapi.utils import is_body_allowed_for_status_code
 
 from cdn import upload_image, upload_version
-from constants import TEMPLATES_DIR, SortDirection, SortType
+from constants import SortDirection, SortType, TEMPLATES_DIR
 from database.database import database, Database
 from discord import post_announcement
 

--- a/plugin_store/api/__init__.py
+++ b/plugin_store/api/__init__.py
@@ -2,17 +2,17 @@ from functools import reduce
 from operator import add
 from os import getenv
 from typing import TYPE_CHECKING, Optional
-from enum import auto
+from enum import Enum
 
 import fastapi
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.security import APIKeyHeader
-from fastapi.utils import is_body_allowed_for_status_code, StrEnum
+from fastapi.utils import is_body_allowed_for_status_code
 
 from cdn import upload_image, upload_version
-from constants import TEMPLATES_DIR
+from constants import TEMPLATES_DIR, SortDirection, SortType
 from database.database import database, Database
 from discord import post_announcement
 
@@ -43,7 +43,6 @@ app.add_middleware(
     expose_headers=["*"],
 )
 
-
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: "Request", exc: "HTTPException") -> "Response":
     headers = getattr(exc, "headers", None)
@@ -64,16 +63,6 @@ async def auth_token(authorization: str = Depends(APIKeyHeader(name="Authorizati
 @app.get("/", response_class=HTMLResponse)
 async def index():
     return INDEX_PAGE
-
-
-# TODO: move these enums somewhere to deduplicate them
-class SortDirection(StrEnum):
-    desc = auto()
-    asc = auto()
-
-class SortType(StrEnum):
-    name = auto()
-    date = auto()
 
 @app.get("/plugins", response_model=list[api_list.ListPluginResponse])
 async def plugins_list(

--- a/plugin_store/constants.py
+++ b/plugin_store/constants.py
@@ -4,3 +4,14 @@ BASE_DIR = Path(__file__).expanduser().resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"
 
 CDN_URL = "https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/"
+
+
+from enum import Enum
+class SortDirection(Enum):
+    desc = "desc"
+    asc = "asc"
+
+class SortType(Enum):
+    name = "name"
+    date = "date"
+    

--- a/plugin_store/constants.py
+++ b/plugin_store/constants.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
 
 BASE_DIR = Path(__file__).expanduser().resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"

--- a/plugin_store/constants.py
+++ b/plugin_store/constants.py
@@ -1,12 +1,11 @@
 from pathlib import Path
+from enum import Enum
 
 BASE_DIR = Path(__file__).expanduser().resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"
 
 CDN_URL = "https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/"
 
-
-from enum import Enum
 class SortDirection(Enum):
     desc = "desc"
     asc = "asc"
@@ -14,4 +13,3 @@ class SortDirection(Enum):
 class SortType(Enum):
     name = "name"
     date = "date"
-    

--- a/plugin_store/constants.py
+++ b/plugin_store/constants.py
@@ -6,9 +6,11 @@ TEMPLATES_DIR = BASE_DIR / "templates"
 
 CDN_URL = "https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/"
 
+
 class SortDirection(Enum):
     desc = "desc"
     asc = "asc"
+
 
 class SortType(Enum):
     name = "name"

--- a/plugin_store/database/database.py
+++ b/plugin_store/database/database.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import delete, select
 from sqlalchemy import asc, desc
 
+from constants import SortDirection, SortType
 from .models.Artifact import Artifact, PluginTag, Tag
 from .models.Version import Version
 
@@ -36,22 +37,6 @@ AsyncSessionLocal = sessionmaker(
 )
 
 db_lock = Lock()
-
-from enum import Enum, auto
-# TODO: move these enums somewhere to deduplicate them
-# also note that these StrEnums are from the python library, but the other ones are from fastapi.
-# i'm not sure what to do about that to be honest...
-####
-class SortDirection(StrEnum):
-    desc = auto()
-    asc = auto()
-
-class SortType(StrEnum):
-    name = auto()
-    date = auto()
-
-####
-
 
 async def get_session() -> "AsyncIterator[AsyncSession]":
     try:
@@ -181,8 +166,8 @@ class Database:
         if not include_hidden:
             statement = statement.where(Artifact.visible.is_(True))
         
-        if sort_direction == SortDirection.asc: direction = asc()
-        else: direction = desc()
+        if sort_direction == SortDirection.asc: direction = asc
+        else: direction = desc
         if sort_by == SortType.name: statement = statement.order_by(direction(Artifact.name))
         if sort_by == SortType.date: statement = statement.order_by(direction(Artifact.created))
 

--- a/plugin_store/database/database.py
+++ b/plugin_store/database/database.py
@@ -38,6 +38,7 @@ AsyncSessionLocal = sessionmaker(
 
 db_lock = Lock()
 
+
 async def get_session() -> "AsyncIterator[AsyncSession]":
     try:
         yield AsyncSessionLocal()
@@ -166,10 +167,14 @@ class Database:
         if not include_hidden:
             statement = statement.where(Artifact.visible.is_(True))
         
-        if sort_direction == SortDirection.asc: direction = asc
-        else: direction = desc
-        if sort_by == SortType.name: statement = statement.order_by(direction(collate(Artifact.name, 'NOCASE')))
-        if sort_by == SortType.date: statement = statement.order_by(direction(Artifact.created))
+        if sort_direction == SortDirection.asc:
+            direction = asc
+        else:
+            direction = desc
+        if sort_by == SortType.name:
+            statement = statement.order_by(direction(collate(Artifact.name, 'NOCASE')))
+        if sort_by == SortType.date:
+            statement = statement.order_by(direction(Artifact.created))
 
         result = (await session.execute(statement)).scalars().all()
         return result or []

--- a/plugin_store/database/database.py
+++ b/plugin_store/database/database.py
@@ -172,6 +172,7 @@ class Database:
             direction = asc
         else:
             direction = desc
+            
         if sort_by == SortType.name:
             statement = statement.order_by(direction(collate(Artifact.name, "NOCASE")))
         if sort_by == SortType.date:

--- a/plugin_store/database/database.py
+++ b/plugin_store/database/database.py
@@ -172,7 +172,6 @@ class Database:
             direction = asc
         else:
             direction = desc
-            
         if sort_by == SortType.name:
             statement = statement.order_by(direction(collate(Artifact.name, "NOCASE")))
         if sort_by == SortType.date:

--- a/plugin_store/database/database.py
+++ b/plugin_store/database/database.py
@@ -2,20 +2,21 @@ import logging
 from asyncio import Lock
 from datetime import datetime
 from os import getenv
-from typing import TYPE_CHECKING, Optional
+from typing import Optional, TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
 from alembic import command
 from alembic.config import Config
 from asgiref.sync import sync_to_async
 from fastapi import Depends
+from sqlalchemy import asc, desc
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql import delete, select, collate
-from sqlalchemy import asc, desc
+from sqlalchemy.sql import collate, delete, select
 
 from constants import SortDirection, SortType
+
 from .models.Artifact import Artifact, PluginTag, Tag
 from .models.Version import Version
 
@@ -166,13 +167,13 @@ class Database:
                 statement = statement.filter(Artifact.tags.any(tag=tag))
         if not include_hidden:
             statement = statement.where(Artifact.visible.is_(True))
-        
+
         if sort_direction == SortDirection.asc:
             direction = asc
         else:
             direction = desc
         if sort_by == SortType.name:
-            statement = statement.order_by(direction(collate(Artifact.name, 'NOCASE')))
+            statement = statement.order_by(direction(collate(Artifact.name, "NOCASE")))
         if sort_by == SortType.date:
             statement = statement.order_by(direction(Artifact.created))
 

--- a/plugin_store/database/database.py
+++ b/plugin_store/database/database.py
@@ -12,7 +12,7 @@ from fastapi import Depends
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql import delete, select
+from sqlalchemy.sql import delete, select, collate
 from sqlalchemy import asc, desc
 
 from constants import SortDirection, SortType
@@ -168,7 +168,7 @@ class Database:
         
         if sort_direction == SortDirection.asc: direction = asc
         else: direction = desc
-        if sort_by == SortType.name: statement = statement.order_by(direction(Artifact.name))
+        if sort_by == SortType.name: statement = statement.order_by(direction(collate(Artifact.name, 'NOCASE')))
         if sort_by == SortType.date: statement = statement.order_by(direction(Artifact.created))
 
         result = (await session.execute(statement)).scalars().all()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -85,7 +85,7 @@ async def test_plugin_list_endpoint_cors(
 @pytest.mark.parametrize(
     ("plugin_sort", "plugin_sort_direction", "id_order"),
     [
-        pytest.param(None, None, [1, 2, 3, 4, 5, 6, 7, 8], id="default-sort"),
+        pytest.param(None, None, [1, 2, 3, 4, 5, 6, 7, 8], id="no-sort"),
         pytest.param(SortType.name, None, [3, 7, 8, 6, 5, 4, 2, 1], id="name-sort"),
         pytest.param(SortType.name, SortDirection.desc, [3, 7, 8, 6, 5, 4, 2, 1], id="name-desc-sort"),
         pytest.param(SortType.name, SortDirection.asc, [1, 2, 4, 5, 6, 8, 7, 3], id="name-asc-sort"),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -85,7 +85,7 @@ async def test_plugin_list_endpoint_cors(
 @pytest.mark.parametrize(
     ("plugin_sort", "plugin_sort_direction", "id_order"),
     [
-        pytest.param(None, None, [1, 2, 3, 4, 5, 6, 7, 8], id="no-sort"),
+        pytest.param(None, None, [1, 2, 3, 4, 5, 6, 7, 8], id="default-sort"),
         pytest.param(SortType.name, None, [3, 7, 8, 6, 5, 4, 2, 1], id="name-sort"),
         pytest.param(SortType.name, SortDirection.desc, [3, 7, 8, 6, 5, 4, 2, 1], id="name-desc-sort"),
         pytest.param(SortType.name, SortDirection.asc, [1, 2, 4, 5, 6, 8, 7, 3], id="name-asc-sort"),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -350,7 +350,7 @@ async def test_plugins_list_endpoint(
     assert response.status_code == 200
     assert response.json() == sorted(
         [response_obj for response_obj in expected_response if response_obj["id"] in plugin_ids],
-        key=lambda obj: plugin_id_order.index(obj["id"]),
+        key=lambda obj: plugin_id_order.index(obj["id"]), # type: ignore[arg-type]
     )
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -350,7 +350,7 @@ async def test_plugins_list_endpoint(
     assert response.status_code == 200
     assert response.json() == sorted(
         [response_obj for response_obj in expected_response if response_obj["id"] in plugin_ids],
-        key=lambda obj: plugin_id_order.index(obj["id"]), # type: ignore[arg-type]
+        key=lambda obj: plugin_id_order.index(obj["id"]),  # type: ignore[arg-type]
     )
 
 


### PR DESCRIPTION
adds `sort_by` and  `sort_direction` to /plugins query with options [`name` and `date`] and [`asc` and `desc`] respectively. No idea if it actually works, as i have zero clue how to test this stuff. (i intend to add more sorting options later)