### PR TITLE
[Documentation] New README for clear information for developers and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more information about Decky Loader as well as documentation and development
 
 🐍 Backend written in [Python](https://www.python.org/) with the [FastAPI](https://fastapi.tiangolo.com/) and [SQLAlchemy](https://www.sqlalchemy.org/) ([SQLite](https://www.sqlite.org/index.html) database [in use](https://github.com/SteamDeckHomebrew/decky-plugin-store/blob/main/plugin_store/database/database.py)) frameworks.
 
-[<ul> 🏤 <i>PostgreSQL support is currently in development.</i> </ul>](https://github.com/SteamDeckHomebrew/decky-plugin-store/tree/postgresql)
+[<ul> 🏤 <i>PostgreSQL support is currently in development.</i> </ul>](https://github.com/SteamDeckHomebrew/decky-plugin-store/pull/54)
 
 🌐 [Frontend](https://github.com/SteamDeckHomebrew/decky-plugin-store/blob/main/plugin_store/templates/plugin_browser.html) (for web browsers) written in [JavaScript](https://developer.mozilla.org/en-US/docs/Web/javascript) with the [Vue.js](https://vuejs.org/) framework
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,33 @@ For more information about Decky Loader as well as documentation and development
 
 📦 Available as a [GitHub Package](https://github.com/SteamDeckHomebrew/decky-plugin-store/pkgs/container/decky-plugin-store) & ready to go as a [Docker](https://www.docker.com/) deployment.
 
-🫸 Data rate limiting
-
-
 ## 💾 Installation
-T.B.D.
+⚠️ **You will need the following to host a plugin store**: a domain name (for external access) and [Backblaze B2 Cloud Storage](https://www.backblaze.com/cloud-storage) to use for plugin storage.   
+  
+- [Install Docker](https://docs.docker.com/get-docker/) on your preferred platform
 
-## 🚀 Getting Started
+- Make sure to have the required [Environment Variables](https://docs.docker.com/engine/reference/run/#environment-variables) ready in an `.env` file where the `docker-compose.yml` file is located at:
+
+  - `DB_PATH`
+    > Database path where to put the SQLite databases
+  - `ANNOUNCEMENT_WEBHOOK`
+    > URL for [Discord webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) for new plugins and updates
+  - `SUBMIT_AUTH_KEY`
+    > API key for REST API requests to use for authentication; other systems are required to use this API key to be able to use the authentication-locked API endpoints
+  - `B2_APP_KEY_ID`
+    >  Backblaze B2 Master [App Key ID](https://www.backblaze.com/docs/cloud-storage-application-keys) (per account) 
+  - `B2_APP_KEY`
+    > Backblaze B2 [App Key](https://www.backblaze.com/docs/cloud-storage-application-keys) 
+  - `B2_BUCKET_ID`
+    > Backblaze B2 [Bucket ID](https://www.backblaze.com/docs/cloud-storage-application-keys) for restricting access to a single bucket
+    
+- Run the Docker environment with the following command:
+  
+  `docker compose up`
+
+  > Use `-d` after `docker compose up` to run it in the background, not taking the current terminal window for logs.
+  
+  > For local deployments, use the `-f docker-compose.local.yml` flag before `up`. The default API key for API requests is `deadbeef` for local deployments.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,31 @@ For more information about Decky Loader as well as documentation and development
 📦 Available as a [GitHub Package](https://github.com/SteamDeckHomebrew/decky-plugin-store/pkgs/container/decky-plugin-store) & ready to go as a [Docker](https://www.docker.com/) deployment.
 
 ## 💾 Installation
+
+### Adding Storefront to Decky Loader
+
+⚠️ **Currently, Decky Loader accepts ONE custom store.**
+
+⚠️ **Currently, Decky Loader accepts updates from ONE store at the time.** 
+
+While switching stores keeps the plugins from any installed source installed, auto checking updates will not happen for all three channels (Stable, Testing and Custom). Only the currently selected Store Channel will be checked for plugin updates.
+
+⚠️ **[In the future](https://github.com/SteamDeckHomebrew/decky-loader/pull/600), custom stores will get a warning message pop up regarding third party plugins and plugin stores.**
+
+Due to the SteamDeckHomebrew / Decky Loader team not being responsible for third party plugins and stores, a warning will be displayed where the user would have to accept the potential risks of using third party software with Decky Loader.
+
+---
+
+- Open your Decky Loader tab
+- Click on the Settings button (displayed as a Cog)
+- Stay on the General tab
+- Change the Store Channel to Custom
+- Fill in the URL in the Custom Store URL text field underneath Store Channel
+
+![Screenshot of Decky Loader's settings screen. Go to the General tag, change the Store Channel option to Custom and fill in the Custom Store URL in the URL text field.](images/CustomStoreConfig.png)
+
+### Hosting a Decky Loader Plugin Storefront
+
 ⚠️ **You will need the following to host a plugin store**: a domain name (for external access) and [Backblaze B2 Cloud Storage](https://www.backblaze.com/cloud-storage) to use for plugin storage.   
   
 - [Install Docker](https://docs.docker.com/get-docker/) on your preferred platform

--- a/README.md
+++ b/README.md
@@ -1,8 +1,53 @@
 # Plugin-Store
 
-This project powers Decky plugin store @ https://plugins.deckbrew.xyz/. It is using fastapi and sqlalchemy. 
+## 📖 About
+The Decky Plugin Store powers the [built-in plugin storefront](https://plugins.deckbrew.xyz/) of [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader) for Steam Deck. It can be used to host Decky Loader compatible plugins for any use case, including hosting testing plugins and providing an alternative storefront.
 
-## Contributing
+For more information about Decky Loader as well as documentation and development tools, please visit [our wiki](https://deckbrew.xyz/).
+
+### 🎨 Features
+
+🐍 Backend written in [Python](https://www.python.org/) with the [FastAPI](https://fastapi.tiangolo.com/) and [SQLAlchemy](https://www.sqlalchemy.org/) ([SQLite](https://www.sqlite.org/index.html) database [in use](https://github.com/SteamDeckHomebrew/decky-plugin-store/blob/main/plugin_store/database/database.py)) frameworks.
+
+[<ul> 🏤 <i>PostgreSQL support is currently in development.</i> </ul>](https://github.com/SteamDeckHomebrew/decky-plugin-store/tree/postgresql)
+
+🌐 [Frontend](https://github.com/SteamDeckHomebrew/decky-plugin-store/blob/main/plugin_store/templates/plugin_browser.html) (for web browsers) written in [JavaScript](https://developer.mozilla.org/en-US/docs/Web/javascript) with the [Vue.js](https://vuejs.org/) framework
+
+📤 API [endpoints](https://github.com/SteamDeckHomebrew/decky-plugin-store/blob/main/plugin_store/api/__init__.py) for:
+  <ul>
+
+  📃 List of plugins 
+  <ul>GET endpoint used by Decky Loader's built-in plugin browser</ul>
+
+  📩 Uploading plugins
+  
+  ♻️ Updating plugins
+  </ul>
+
+🪣 [Backblaze B2 Cloud Storage](https://www.backblaze.com/cloud-storage) supported for hosting plugins & metadata as a [CDN](https://github.com/SteamDeckHomebrew/decky-plugin-store/blob/main/plugin_store/cdn.py).
+
+<ul>
+
+🖼️ Handling image types for preview screenshots
+
+🔑 Handling uploads via an `APP_KEY` 
+
+♻️ Handling uploading different available versions of plugins
+</ul>
+
+💬 [Discord webhook](https://discord.com/developers/docs/resources/webhook) support for [sending notifications](https://github.com/SteamDeckHomebrew/decky-plugin-store/blob/main/plugin_store/discord.py) for new uploaded plugin versions
+
+📦 Available as a [GitHub Package](https://github.com/SteamDeckHomebrew/decky-plugin-store/pkgs/container/decky-plugin-store) & ready to go as a [Docker](https://www.docker.com/) deployment.
+
+🫸 Data rate limiting
+
+
+## 💾 Installation
+T.B.D.
+
+## 🚀 Getting Started
+
+## 🤝 Contributing
 
 ### Running in docker
 

--- a/images/CustomStoreConfig.png
+++ b/images/CustomStoreConfig.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7de5a3af519d7d981cb72a75dfc8e419eb456859c68d5fccb5a9812e1e8f325
+size 75868


### PR DESCRIPTION
# Context

The Decky Plugin Store repository currently lacks the documentation for showing which tech has been used, what is necessary to run a self-hosted Decky Loader plugin storefront and pointers where to look for making modifications for those self-hosted storefronts.

The [Decky Loader repository](https://github.com/SteamDeckHomebrew/decky-loader) has a more comprehensive README which shows the featureset, common issues and installation instructions.

# Proposal

My Pull Request tries to close the gap between both repositories regarding documentation in the README file by making the following changes:

- Mentioning more specifics regarding the used tech along with hyperlinks pointing to relevant code or documentation.
- Mentioning the featureset (customisable frontend, endpoints, cloud storage, webhook, package options) for developers to get a clearer view what is currently possible with the storefront code.
- Clear installation instructions for using a custom store with Decky Loader.
- Clear installation instructions how to deploy the project with Docker, including prequesities for self-hosting the store.
- Mentioning possible future changes (PostgreSQL support, third party plugin & repository warnings) noteworthy to developers.
- Stylise it as much as possible with the Decky Loader's README style.

While there are some fields untouched (e.g.: how to customise Decky Store's tag system to add more tags in the plugin browser, rate limiting per plugin), I do hope this will help developers and "self-hosted store hosters" alike to bring more Decky plugin stores to the public.

I'm unable to run a local environment due to the lack of Backblazer environment, so I'd hope some maintainers of the Decky Plugin Store or of any custom store could help out with suggestions and verifying the contents of the README to make it useful for developers.

## TODOs

- [ ] Stylise it to align more with the Decky Loader README:
    - [ ] Screenshot of a custom storefront
    - [ ] Statistics buttons
    - [ ] Using Steam & Decky Loader button icons for clearer user instructions
- [ ] Adding extra relevant developer information (possible suggestions:)
    - [ ] Customising plugin store tags
    - [ ] Customising certain web pages to distinguish more from the official Decky Loader store channels
    - [ ] Common Issues
    - [ ] Clearer contribution instructions akin to Decky Loader's README
