### PR TITLE
fix: Field types for versions

### DIFF
--- a/plugin_store/database/migrations/versions/2022_11_07_0136_4fc55239b4d6_initial_db_setup.py
+++ b/plugin_store/database/migrations/versions/2022_11_07_0136_4fc55239b4d6_initial_db_setup.py
@@ -9,6 +9,8 @@ Create Date: 2022-11-07 01:36:59.727609
 import sqlalchemy as sa
 from alembic import op
 
+from database import utils
+
 # revision identifiers, used by Alembic.
 revision = "4fc55239b4d6"
 down_revision = None
@@ -44,7 +46,7 @@ def upgrade() -> None:
         sa.Column("artifact_id", sa.Integer(), nullable=True),
         sa.Column("name", sa.Text(), nullable=True),
         sa.Column("hash", sa.Text(), nullable=True),
-        sa.Column("added_on", sa.DateTime(), nullable=True),
+        sa.Column("added_on", utils.TZDateTime(), nullable=True),
         sa.ForeignKeyConstraint(("artifact_id",), ["artifacts.id"]),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/plugin_store/database/models/Version.py
+++ b/plugin_store/database/models/Version.py
@@ -15,8 +15,8 @@ class Version(Base):
     name = Column(Text)
     hash = Column(Text)
     file_field = Column("file", Text, nullable=True)
-    downloads = Column(Integer, default=0)
-    updates = Column(Integer, default=0)
+    downloads = Column(Integer, default=0, nullable=False)
+    updates = Column(Integer, default=0, nullable=False)
 
     created = Column("added_on", TZDateTime)
 


### PR DESCRIPTION
- `downloads` and `uploads` were made as non-nullable in database, but they're defined as nullable in model.
- `added_on` had wrong field type - it's the same type in DB, but differently handled in code. Adjusted migration to match the model.