### PR TITLE
Added endpoint to get plugins by their ID

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - store-postgres:/var/lib/postgresql/data
     healthcheck:
-      test: pg_isready -U myuser -d db_prod
+      test: pg_isready -U decky -d decky
       interval: 10s
       timeout: 3s
       retries: 3

--- a/plugin_store/api/__init__.py
+++ b/plugin_store/api/__init__.py
@@ -17,6 +17,8 @@ from database.database import database, Database
 from database.models import Announcement
 from discord import post_announcement
 
+from sqlalchemy.exc import NoResultFound
+
 from .models import announcements as api_announcements
 from .models import delete as api_delete
 from .models import list as api_list
@@ -154,6 +156,16 @@ async def plugins_list(
     plugins = await db.search(db.session, query, tags, hidden, sort_by, sort_direction)
     return plugins
 
+@app.get("/plugins/{id}", response_model=api_list.ListPluginResponse, responses={404: {}})
+async def get_plugin(
+        id: int,
+        db: "Database" = Depends(database),
+):
+    try:
+        plugin = await db.get_plugin_by_id(db.session, id)
+        return plugin
+    except NoResultFound:
+        return Response(status_code=fastapi.status.HTTP_404_NOT_FOUND)
 
 @app.post("/plugins/{plugin_name}/versions/{version_name}/increment", responses={404: {}, 429: {}})
 async def increment_plugin_install_count(


### PR DESCRIPTION
## Changes
Added a new endpoint to get plugins by their ID.

Usage: `GET http://localhost:5566/plugins/2` will return the plugin with id 2, if no plugin could be found for the ID then a 404 not found is given.

## Why?
I wanted to fix the downloads badge in my plugin's repository, but could not figure out why the JSONPath was not working (probably a skill issue), with this endpoint it will be easier.



