### PR TITLE
chore: Update vue cdn url to use jsdelivr

### DIFF
--- a/plugin_store/templates/plugin_browser.html
+++ b/plugin_store/templates/plugin_browser.html
@@ -6,7 +6,7 @@
   <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js"></script>
-  <script src="https://cdn.tzatzikiweeb.moe/file/tzatzikiweeb-public/static/js/vue.global.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@3.5.17/dist/vue.global.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
https://plugins.deckbrew.xyz is not loading due to a JS error:
```
plugins.deckbrew.xyz/:9 GET https://cdn.tzatzikiweeb.moe/file/tzatzikiweeb-public/static/js/vue.global.js net::ERR_HTTP2_PROTOCOL_ERROR 200 (OK)
(index):57 Uncaught ReferenceError: Vue is not defined at (index):57:5
```

VueJs file is not found. This PR updates it to use jsdelivr similar to the other dependencies on the page.
I've assumed that latest Vue version is ok, but version number may need to be adjusted.