### PR TITLE
Prevent search form from submit/reset when hitting enter/return key

### DIFF
--- a/plugin_store/templates/plugin_browser.html
+++ b/plugin_store/templates/plugin_browser.html
@@ -18,7 +18,7 @@
             <img src="https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/SDHomeBrewwwww.png" width="48" height="48">
             Plugins
           </a>
-          <form class="d-flex">
+          <form class="d-flex" @submit.prevent>
             <input v-on:change="searchPlugins" v-model="search_input" class="form-control me-2" type="search"
               placeholder="Search" aria-label="Search">
           </form>


### PR DESCRIPTION
If you hit enter/return on mobile or desktop, the entire page is reloaded, instead of running the search query. This PR fixes that.

> It is a very common need to call event.preventDefault() or event.stopPropagation() inside event handlers. Although we can do this easily inside methods, it would be better if the methods can be purely about data logic rather than having to deal with DOM event details.
```
<!-- just the modifier -->
<form @submit.prevent></form>
```

https://vuejs.org/guide/essentials/event-handling#event-modifiers