### PR TITLE
Mobile viewport scale, bootstrap layout, lazy load images

### DIFF
--- a/plugin_store/templates/plugin_browser.html
+++ b/plugin_store/templates/plugin_browser.html
@@ -2,17 +2,16 @@
 <html>
 
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js"></script>
   <script src="https://cdn.tzatzikiweeb.moe/file/tzatzikiweeb-public/static/js/vue.global.js"></script>
 </head>
-
-<body>
-  <div class="container-fluid" id="mainBind">
-    <div class="row" style="padding: 1rem;">
-      <nav class="navbar navbar-light bg-light">
+<body id="mainBind">
+  <header>
+    <nav class="navbar navbar-light bg-light">
         <div class="container">
           <a class="navbar-brand" href="#">
             <img src="https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/SDHomeBrewwwww.png" width="48" height="48">
@@ -24,7 +23,8 @@
           </form>
         </div>
       </nav>
-    </div>
+  </header>
+  <main role="main">
     <div class="container" style="padding: 1rem;">
       <div v-for="plugin in plugins" class="card">
         <div class="card-body">
@@ -32,7 +32,7 @@
             <div class="col-3">
               <img
                 v-bind:src="plugin.image_url"
-                class="img-fluid rounded-start">
+                class="img-fluid rounded-start" loading="lazy">
             </div>
             <div class="col">
               <h5 class="card-title">{{ plugin.name }}</h5>
@@ -52,7 +52,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </main>
   <script>
     Vue.createApp({
       data() {


### PR DESCRIPTION
Features:
1. Prevent mobile from zooming out the page on load
2. Remove extra spacing cramping mobile view
3. Lazy loading images only loads images in view (mobile optimization)

Before:
<img width="300" alt="Before" src="https://github.com/user-attachments/assets/49f9a8ed-1b6e-4832-b004-29c8c2647afd" />

After:
<img width="300" alt="After" src="https://github.com/user-attachments/assets/3d9be15f-a075-4b9f-885e-aa867310eae0" />
